### PR TITLE
Remove version locks for npm and libsass

### DIFF
--- a/7.4/ansible/roles/flight-deck-web-build/tasks/main.yml
+++ b/7.4/ansible/roles/flight-deck-web-build/tasks/main.yml
@@ -67,15 +67,9 @@
     - "freetds-dev"
   notify:
     - clear caches
-# Install node from Alpine 3.12 as Node SASS doesn't support the newer node on
-# the Alpine 3.13 repos just yet.
 - name: Install node
   command: >
-    apk add
-    --repository https://dl-cdn.alpinelinux.org/alpine/v3.12/main
-    nodejs=12.22.1-r0
-    nodejs-npm=12.22.1-r0
-    libsass=3.6.4-r0
+    apk add nodejs nodejs-npm libsass
 - name: Ensure key directories are owned by apache
   file:
     path: "{{ item }}"


### PR DESCRIPTION
This change is needed to be able to build flightdeck-web-7.4 on an M1 MacBook Pro.  With this, we can build an arm64 image, run it in Docker, and I was able to rebuild theme assets locally.